### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,8 @@ EOF
 Download a kjob [release](https://github.com/stefanprodan/kjob/releases) and run the job:
 
 ```text
+kjob run --kubeconfig=$HOME/.kube/config -t curl
+
+# Or pass a namespace
 kjob run --kubeconfig=$HOME/.kube/config -t curl -n test
 ```


### PR DESCRIPTION
Example CLI command in README included a test
namespace which did not work when tested with 
example YAML snippet.